### PR TITLE
Bugfix for qGUI on Windows

### DIFF
--- a/qtools2/qgui.py
+++ b/qtools2/qgui.py
@@ -191,10 +191,15 @@ class PmaConvert:
             ('XLSX Files', '*.xlsx'),
             ('All files', '*')
         ]
-        self.file_selection = tkFileDialog.askopenfilename(
-            filetypes=file_types, title='Open one or more files.',
-            message='Open one or more files', multiple=1
-        )
+        try:
+            self.file_selection = tkFileDialog.askopenfilename(
+                filetypes=file_types, title='Open one or more files.',
+                message='Open one or more files', multiple=1
+            )
+        except:
+            self.file_selection = tkFileDialog.askopenfilename(
+                filetypes=file_types, title='Open one or more files.', multiple=1
+            )
         if self.file_selection != '':
             self.set_status('Click on Convert to convert files.')
             log_output = 'Ready for conversion: \n'


### PR DESCRIPTION
**Bugfix for qGUI on Windows: **

```Exception in Tkinter callback
Traceback (most recent call last):
  File C:Python27liblib-tkTkinter.py, line 1542, in __call__
    return self.func(*args)
  File C:Python27libsite-packagesqtools2qgui.py, line 196, in on_open
    message='Open one or more files', multiple=1
  File C:Python27liblib-tktkFileDialog.py, line 125, in askopenfilename
    return Open(**options).show()
  File C:Python27liblib-tktkCommonDialog.py, line 48, in show
    s = w.tk.call(self.command, *w._options(self.options))
TclError: bad option -message: must be -defaultextension, -filetypes, -initialdir, -initialfile, -multiple, -parent, -title, or -typevariable```